### PR TITLE
make the Dockerfile able to build+test+assemble the application

### DIFF
--- a/testRunnerImage/Dockerfile
+++ b/testRunnerImage/Dockerfile
@@ -1,7 +1,0 @@
-FROM amazoncorretto:11
-RUN yum -y install python3 \
-    python3-pip \
-    shadow-utils \
-    util-linux
-RUN adduser gatekeeper
-USER gatekeeper


### PR DESCRIPTION
# Jira Issue: [HVG-1041] 

## What?
Give the dockerfile the power to build both integration test and production images.

## Why?
This is our way to achieve very similar builds for all services, letting the differences be spelled out in the repo itself using Docker.
https://docs.google.com/spreadsheets/d/1PVW1vsiT7fccsCsqzbOalOYEDZAoJotzhsNMho9p1VE/edit#gid=0

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally



[HVG-1041]: https://hedvig.atlassian.net/browse/HVG-1041